### PR TITLE
Submit to the main product repo

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ Yast::Tasks.configuration do |conf|
   conf.obs_api = "https://api.suse.de/"
   conf.obs_project = "Devel:YaST:CASP:1.0"
   conf.obs_target = "CASP_1.0"
-  conf.obs_sr_project = "Devel:CASP:1.0"
+  conf.obs_sr_project = "SUSE:SLE-12-SP2:Update:Products:CASP10"
 
   # lets ignore license check for now
   conf.skip_license_check << /.*/


### PR DESCRIPTION
the package was deleted from Devel:CASP:1.0 because we develop it in
Devel:YaST:CASP:1.0 so submit it to
SUSE:SLE-12-SP2:Update:Products:CASP10

This should fix the failure in https://ci.suse.de/job/yast-skelcd-control-CASP-master/7/console