### PR TITLE
Replace system roles by CASP roles.

### DIFF
--- a/control/control.CASP.xml
+++ b/control/control.CASP.xml
@@ -115,7 +115,8 @@ textdomain="control"
         <selection_type config:type="symbol">auto</selection_type>
 
         <!-- bnc#875350: Explicitly selecting these patterns by default -->
-        <!-- For a list of patterns, see https://build.suse.de/package/view_file/SUSE:SLE-12-SP1:GA/patterns-sles/patterns-sles.spec?expand=1 -->
+        <!-- For a list of patterns, see https://build.suse.de/package/view_file/SUSE:SLE-12-SP2:Update:Products:CASP10/patterns-casp/patterns-casp.spec?expand=1 -->
+
         <default_patterns>MicroOS Stack</default_patterns>
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
@@ -239,37 +240,15 @@ textdomain="control"
       <system_role>
         <!-- the id is a key for texts/$id/label
                              and texts/$id_description/label below -->
-        <id>normal_role</id>
-        <!-- nothing is overlaid for the normal role -->
+        <id>dashboard_role</id>
       </system_role>
 
       <system_role>
-        <id>kvm_host_role</id>
-
-        <!-- the rest is overlaid over the feature sections and values. -->
-        <partitioning>
-          <try_separate_home config:type="boolean">false</try_separate_home>
-        </partitioning>
-        <software>
-          <default_patterns>base Minimal kvm_server</default_patterns>
-          <!-- the cdata trick produces an empty string in the data
-               instead of omitting the key entirely -->
-          <optional_default_patterns><![CDATA[]]></optional_default_patterns>
-          <default_desktop><![CDATA[]]></default_desktop>
-        </software>
+        <id>worker_role</id>
       </system_role>
 
       <system_role>
-        <id>xen_host_role</id>
-
-        <partitioning>
-          <try_separate_home config:type="boolean">false</try_separate_home>
-        </partitioning>
-        <software>
-          <default_patterns>base Minimal xen_server</default_patterns>
-          <optional_default_patterns><![CDATA[]]></optional_default_patterns>
-          <default_desktop><![CDATA[]]></default_desktop>
-        </software>
+        <id>none_role</id>
       </system_role>
     </system_roles>
 
@@ -323,44 +302,41 @@ Please visit us at http://www.suse.com/.
         <service_sfcb><label>CIM Server</label></service_sfcb>
         <roles_caption>
           <!-- TRANSLATORS: dialog caption -->
-          <label>System Role</label>
+          <label>CASP Roles</label>
         </roles_caption>
         <roles_text>
           <!-- TRANSLATORS: label in a dialog -->
-          <label>System Roles are predefined use cases which tailor the system
+          <label>Roles are predefined use cases which tailor the system
 for the selected scenario.</label>
         </roles_text>
         <roles_help>
           <!-- TRANSLATORS: dialog help -->
-          <label>&lt;p&gt;The system roles adjustments are in the range from package selection up 
-to disk partitioning. By choosing a system role, the system is 
-configured accordingly to match the use case of the role. The settings 
-defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</label>
+          <label>&lt;p&gt;The roles adjustments are in the range from package selection up
+to disk partitioning. By choosing a CASP role, the system is
+configured accordingly to match the use case of the role. &lt;/p&gt;</label>
         </roles_help>
-        <normal_role>
+        <dashboard_role>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Default System</label>
-        </normal_role>
-        <normal_role_description>
-          <label>• GNOME environment, with Btrfs root (/) partition
-• Separate /home partition (XFS) for disks larger than 20GB</label>
-        </normal_role_description>
-        <kvm_host_role>
+          <label>Admin Dashboard</label>
+        </dashboard_role>
+        <dashboard_role_description>
+          <label>• Default system with administration dashboard</label>
+        </dashboard_role_description>
+        <worker_role>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>KVM Virtualization Host</label>
-        </kvm_host_role>
-        <kvm_host_role_description>
-          <label>• Kernel-based hypervisor and tools
-• No separate /home partition</label>
-        </kvm_host_role_description>
-        <xen_host_role>
+          <label>Worker</label>
+        </worker_role>
+        <worker_role_description>
+          <label>• Default system registering as worker at the admin dashboard</label>
+        </worker_role_description>
+        <none_role>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Xen Virtualization Host</label>
-        </xen_host_role>
-        <xen_host_role_description>
-          <label>• Bare metal hypervisor and tools
-• No separate /home partition</label>
-        </xen_host_role_description>
+          <label>None</label>
+        </none_role>
+        <none_role_description>
+          <!-- TRANSLATORS: a label for a system role -->
+          <label>• Default system, no services started by default</label>
+        </none_role_description>
     </texts>
 
     <proposals config:type="list">

--- a/control/control.CASP.xml
+++ b/control/control.CASP.xml
@@ -245,6 +245,8 @@ textdomain="control"
 
       <system_role>
         <id>worker_role</id>
+
+        <additional_dialogs>inst_worker_role</additional_dialogs>
       </system_role>
 
       <system_role>

--- a/control/control.CASP.xml
+++ b/control/control.CASP.xml
@@ -304,40 +304,39 @@ Please visit us at http://www.suse.com/.
         <service_sfcb><label>CIM Server</label></service_sfcb>
         <roles_caption>
           <!-- TRANSLATORS: dialog caption -->
-          <label>CASP Roles</label>
+          <label>System Role</label>
         </roles_caption>
         <roles_text>
           <!-- TRANSLATORS: label in a dialog -->
-          <label>Roles are predefined use cases which tailor the system
+          <label>System Roles are predefined use cases which tailor the system
 for the selected scenario.</label>
         </roles_text>
         <roles_help>
           <!-- TRANSLATORS: dialog help -->
-          <label>&lt;p&gt;The roles adjustments are in the range from package selection up
-to disk partitioning. By choosing a CASP role, the system is
+          <label>&lt;p&gt;The system roles adjustments are in the range from package selection up
+to disk partitioning. By choosing a system role, the system is
 configured accordingly to match the use case of the role. &lt;/p&gt;</label>
         </roles_help>
         <dashboard_role>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Admin Dashboard</label>
+          <label>Administration Dashboard</label>
         </dashboard_role>
         <dashboard_role_description>
-          <label>• Default system with administration dashboard</label>
+          <label>• A set of tools and a dashboard for managing workers.</label>
         </dashboard_role_description>
         <worker_role>
           <!-- TRANSLATORS: a label for a system role -->
           <label>Worker</label>
         </worker_role>
         <worker_role_description>
-          <label>• Default system registering as worker at the admin dashboard</label>
+          <label>• The system is registered as a worker in a given administration dashboard.</label>
         </worker_role_description>
         <none_role>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>None</label>
+          <label>Plain System</label>
         </none_role>
         <none_role_description>
-          <!-- TRANSLATORS: a label for a system role -->
-          <label>• Default system, no services started by default</label>
+          <label>• No services started by default.</label>
         </none_role_description>
     </texts>
 

--- a/package/skelcd-control-CASP.changes
+++ b/package/skelcd-control-CASP.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 14 12:31:14 UTC 2016 - kanderssen@suse.com
+
+- Added System Roles for CASP (FATE#321754).
+- 12.2.11
+
+-------------------------------------------------------------------
 Wed Dec 14 12:30:32 CET 2016 - shundhammer@suse.de
 
 - Added new parameter for CASP read-only Btrfs root subvolume

--- a/package/skelcd-control-CASP.spec
+++ b/package/skelcd-control-CASP.spec
@@ -88,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CASP
 AutoReqProv:    off
-Version:        12.2.10
+Version:        12.2.11
 Release:        0
 Summary:        CASP control file needed for installation
 License:        MIT


### PR DESCRIPTION
A proposal for [CASP roles](https://trello.com/c/s1t0IbQy/784-3-casp-roles):

![casprolesupdated](https://cloud.githubusercontent.com/assets/7056681/21183771/5e40e78c-c201-11e6-9637-489de282b718.png)

In the last commit we added an additional dialog to the worker role so now it depends on several other changes:
- https://github.com/yast/yast-installation/pull/470 implementing the `additional_dialogs` behavior
- https://github.com/yast/yast-installation-control/commit/b013ec67a564673bc090e1bd8c07ac73663f1d1d declaring the schema extension 
- https://github.com/yast/yast-installation/pull/474, implementing the particular inst_worker_role dialog

## Blog note

In previous [sprints](https://lizards.opensuse.org/2016/03/15/highlights-of-development-sprint-16/) we added support for roles allowing the user to redefine many settings of the installation based on them. For CASP we will have 3 different roles which will differ mainly in the selection of patterns to be installed as you can see in the screenshot:

![casprolesupdated](https://cloud.githubusercontent.com/assets/7056681/21183771/5e40e78c-c201-11e6-9637-489de282b718.png)

Apart of the patterns selection, each role could implement specific dialogs which is also an improvement added during this sprint. By now the **Worker** role is the only one using this new feature providing a dialog for registering against the **Administration Dashboard's url** provided.

![registerworker](https://cloud.githubusercontent.com/assets/7056681/21173167/5780a636-c1ce-11e6-810f-f408887b8251.png)