### PR TITLE
Added new parameter for CASP read-only Btrfs root subvolume (Fate#321755)

### DIFF
--- a/control/control.CASP.xml
+++ b/control/control.CASP.xml
@@ -143,6 +143,7 @@ textdomain="control"
         <btrfs_default_subvolume>@</btrfs_default_subvolume>
         <proposal_settings_editable config:type="boolean">false</proposal_settings_editable>
         <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>
+        <root_subvolume_read_only config:type="boolean">true</root_subvolume_read_only>
 
         <!-- Subvolumes to be created for a Btrfs root file system -->
         <!-- copy_on_write is true by default -->

--- a/package/skelcd-control-CASP.changes
+++ b/package/skelcd-control-CASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 14 12:30:32 CET 2016 - shundhammer@suse.de
+
+- Added new parameter for CASP read-only Btrfs root subvolume
+  (Fate#321755) 
+- 12.2.10
+
+-------------------------------------------------------------------
 Tue Dec 13 16:25:14 UTC 2016 - jreidinger@suse.com
 
 - Add keyboard and root password combined dialog to installation

--- a/package/skelcd-control-CASP.spec
+++ b/package/skelcd-control-CASP.spec
@@ -88,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CASP
 AutoReqProv:    off
-Version:        12.2.9
+Version:        12.2.10
 Release:        0
 Summary:        CASP control file needed for installation
 License:        MIT


### PR DESCRIPTION
https://trello.com/c/sLkMAwRU/479-3-casp-321755-microos-switch-root-subvolume-to-read-only-s

**Note:** Validating fails in Travis because the other PR that contains the changed XML schema is still in progress: https://github.com/yast/yast-installation-control/pull/32