### PR TITLE
Added subvol for docker, not libvirt (bsc#1015720)

### DIFF
--- a/control/control.CASP.xml
+++ b/control/control.CASP.xml
@@ -173,8 +173,7 @@ textdomain="control"
                 <path>var/lib/cloud</path>
             </subvolume>
             <subvolume>
-                <path>var/lib/libvirt/images</path>
-                <copy_on_write config:type="boolean">false</copy_on_write>
+                <path>var/lib/docker</path>
             </subvolume>
             <subvolume>
                 <path>var/lib/overlay</path>

--- a/package/skelcd-control-CASP.changes
+++ b/package/skelcd-control-CASP.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 19 12:08:02 CET 2016 - shundhammer@suse.de
+
+- Added subvol for docker, not libvirt (bsc#1015720)
+- 12.2.13
+
+-------------------------------------------------------------------
 Wed Dec 14 15:31:51 UTC 2016 - igonzalezsosa@suse.com
 
 - Set timezone as read-only (FATE#321754).

--- a/package/skelcd-control-CASP.spec
+++ b/package/skelcd-control-CASP.spec
@@ -88,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CASP
 AutoReqProv:    off
-Version:        12.2.12
+Version:        12.2.13
 Release:        0
 Summary:        CASP control file needed for installation
 License:        MIT


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1015720

New subvol /var/lib/docker instead of /var/lib/libvirt/images