### PR TITLE
Remove AutoYaST 2nd stage

### DIFF
--- a/control/control.CASP.xml
+++ b/control/control.CASP.xml
@@ -504,38 +504,12 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
             </modules>
         </workflow>
 
-        <workflow>
-            <defaults>
-                <archs>all</archs>
-                <enable_back>no</enable_back>
-                <enable_next>no</enable_next>
-            </defaults>
-            <stage>continue</stage>
-            <mode>autoinstallation</mode>
-            <modules config:type="list">
-                <module>
-                    <label>Perform Installation</label>
-                    <name>autopost</name>
-                </module>
-                <module>
-                    <label>Perform Installation</label>
-                    <name>rpmcopy_secondstage_autoinstall</name>
-                    <execute>inst_rpmcopy_secondstage</execute>
-                </module>
-                <module>
-                    <heading>yes</heading>
-                    <label>Configuration</label>
-                </module>
-                <module>
-                    <label>System Configuration</label>
-                    <name>autoconfigure</name>
-                </module>
-            </modules>
-        </workflow>
-
         <!-- CASP 1 has nothing to upgrade from -->
         <!-- Removed: <mode>update</mode> -->
         <!-- Removed: <mode>autoupgrade</mode> -->
+
+        <!-- CASP 1 does not have AutoYaST second stage -->
+        <!-- Removed: <mode>autoinstallation</mode> && <stage>continue</stage> -->
 
     </workflows>
 </productDefines>

--- a/package/skelcd-control-CASP.changes
+++ b/package/skelcd-control-CASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb  3 14:17:57 UTC 2017 - igonzalezsosa@suse.com
+
+- Remove AutoYaST second stage because it's not available in CaaSP
+  (bsc#1022267)
+- 12.2.20
+
+-------------------------------------------------------------------
 Thu Jan 26 10:08:32 UTC 2017 - jreidinger@suse.com
 
 - initial set of services adaptation for CASP roles (FATE#322328)

--- a/package/skelcd-control-CASP.spec
+++ b/package/skelcd-control-CASP.spec
@@ -88,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CASP
 AutoReqProv:    off
-Version:        12.2.19
+Version:        12.2.20
 Release:        0
 Summary:        CASP control file needed for installation
 License:        MIT


### PR DESCRIPTION
AutoYaST second stage won't be available in CaaSP so it's not needed anymore. Fixes [bsc#1022267](https://bugzilla.novell.com/show_bug.cgi?id=102226).