### PR TITLE
Removed additional dialog for worker role

### DIFF
--- a/control/control.CASP.xml
+++ b/control/control.CASP.xml
@@ -244,8 +244,6 @@ textdomain="control"
       <system_role>
         <id>worker_role</id>
 
-        <additional_dialogs>inst_worker_role</additional_dialogs>
-
         <!-- for worker only salt and rest will be configured -->
         <services config:type="list">
           <service>

--- a/package/skelcd-control-CASP.changes
+++ b/package/skelcd-control-CASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb  7 11:25:44 UTC 2017 - kanderssen@suse.com
+
+- Removed additional dialog for worker role which is not used
+  anymore (FATE#322328).
+- 12.2.21
+
+-------------------------------------------------------------------
 Fri Feb  3 14:17:57 UTC 2017 - igonzalezsosa@suse.com
 
 - Remove AutoYaST second stage because it's not available in CaaSP

--- a/package/skelcd-control-CASP.spec
+++ b/package/skelcd-control-CASP.spec
@@ -88,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CASP
 AutoReqProv:    off
-Version:        12.2.20
+Version:        12.2.21
 Release:        0
 Summary:        CASP control file needed for installation
 License:        MIT


### PR DESCRIPTION
The additional role is not used after the all-in-one-dialog was added to CaaSP so it is removed as part of this PBI:

https://trello.com/c/hBDzHqGs/844-3-caasp-bring-the-minion-worker-role-back-to-life