### PR TITLE
Appended (default) to "Administrative Dashboard" label. 

### DIFF
--- a/control/control.CASP.xml
+++ b/control/control.CASP.xml
@@ -322,7 +322,7 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
         </roles_help>
         <dashboard_role>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>Administration Dashboard</label>
+          <label>Administration Dashboard (default)</label>
         </dashboard_role>
         <dashboard_role_description>
           <label>• A set of tools and a dashboard for managing workers.</label>

--- a/package/skelcd-control-CASP.changes
+++ b/package/skelcd-control-CASP.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 16 12:44:10 UTC 2017 - mfilka@suse.com
+
+- fate#322328
+  - appended (defaul) to "Administrative Dashboard" label to make
+    it more obvious that such role will be used by default.
+- 12.2.23 
+
+-------------------------------------------------------------------
 Tue Feb  7 13:03:25 UTC 2017 - jsrain@suse.cz
 
 - remove installer update also from AutoYaST workflow (bsc#1024032)

--- a/package/skelcd-control-CASP.spec
+++ b/package/skelcd-control-CASP.spec
@@ -88,7 +88,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CASP
 AutoReqProv:    off
-Version:        12.2.22
+Version:        12.2.23
 Release:        0
 Summary:        CASP control file needed for installation
 License:        MIT


### PR DESCRIPTION
fate#322328
The change was based on a feedback provided by Product management
and UX stakeholders when all-in-one dialog was presented.