### PR TITLE
Allow overriding the YAST_SUBMIT in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :casp10
+Yast::Tasks.submit_to((ENV["YAST_SUBMIT"] || :casp10).to_sym)
 
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now


### PR DESCRIPTION
Needed to build/submit to Factory in public Jenkins, the same as in https://github.com/yast/yast-caasp/pull/7.