### PR TITLE
Patterns update, openSUSE support

### DIFF
--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -115,7 +115,7 @@ textdomain="control"
         <!-- bnc#875350: Explicitly selecting these patterns by default -->
         <!-- For a list of patterns, see https://build.suse.de/package/view_file/SUSE:SLE-12-SP2:Update:Products:CASP10/patterns-caasp/patterns-caasp.spec?expand=1 -->
 
-        <default_patterns>MicroOS Stack</default_patterns>
+        <default_patterns>SUSE-MicroOS SUSE-CaaSP-Stack</default_patterns>
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
 

--- a/package/control.Kubic.diff
+++ b/package/control.Kubic.diff
@@ -1,0 +1,18 @@
+--- control/control.CAASP.xml
++++ control/control.CAASP.xml	2017/05/08 10:55:52
+@@ -260,7 +260,6 @@
+         <id>dashboard_role</id>
+ 
+         <services config:type="list">
+-          <service><name>container-feeder</name></service>
+           <service><name>docker</name></service>
+           <service><name>etcd</name></service>
+           <service><name>kubelet</name></service>
+@@ -271,7 +270,6 @@
+         <id>worker_role</id>
+ 
+         <services config:type="list">
+-          <service><name>container-feeder</name></service>
+           <service><name>salt-minion</name></service>
+         </services>
+       </system_role>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May  9 13:47:02 UTC 2017 - lslezak@suse.cz
+
+- Update the default pattern names (bsc#1038267)
+- Adapt the package to build also for openSUSE
+- 12.2.31
+
+-------------------------------------------------------------------
 Thu May  4 08:47:25 UTC 2017 - lslezak@suse.cz
 
 - The package has been renamed from skelcd-control-CASP to

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -102,7 +102,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        12.2.30
+Version:        12.2.31
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package skelcd-control-CAASP
 #
-# Copyright (c) 2016 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -42,7 +42,12 @@ BuildRequires:  yast2-installation-control >= 3.1.13.2
 # SLES specific Yast packages needed in the inst-sys
 # to provide the functionality needed by this control file
 Requires:       yast2-registration
+%if 0%{?is_susecaasp}
 Requires:       yast2-theme-SLE
+%else
+Requires:       yast2-branding-openSUSE
+Requires:       yast2-qt-branding-openSUSE
+%endif
 
 # the CaaSP specific packages
 Requires:       yast2-caasp
@@ -104,6 +109,7 @@ License:        MIT
 Group:          Metapackages
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2
+Patch:          control.Kubic.diff
 
 %description
 The package contains the CaaSP control file needed for installation.
@@ -111,6 +117,9 @@ The package contains the CaaSP control file needed for installation.
 %prep
 
 %setup -n %{name}-%{version}
+%if !0%{?is_susecaasp}
+%patch -p0
+%endif
 
 %check
 #


### PR DESCRIPTION
- The default CaaSP patterns have been renamed
- The package can now be built in openSUSE (see the [devel:CaaSP:1.0](https://build.opensuse.org/project/show/devel:CaaSP:1.0) OBS project)

All changes were proposed/required by Thorsten, don't ask me for details. :wink:   
I just synced the sources with [devel:CaaSP:1.0/skelcd-control-CAASP](https://build.opensuse.org/package/show/devel:CaaSP:1.0/skelcd-control-CAASP) in OBS.

