### PR TITLE
Enable using home partition as generic separate data partition

### DIFF
--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -136,6 +136,12 @@ textdomain="control"
         <try_separate_home config:type="boolean">true</try_separate_home>
         <limit_try_home>40GB</limit_try_home>
         <!-- use /var/lib/docker as separate partition if 10+ GB available (fate#323532) -->
+        
+        <!-- NOTICE: This is a hack, introduced to make this feature possible
+             against all odds at the very latest stages of CaaSP 1.0
+             development without breaking the entire storage proposal logic.
+             It is strongly advised not to use this in general.
+             Please contact the YaST team if you feel you need this. -->
         <home_path>/var/lib/docker</home_path>
         <root_space_percent>75</root_space_percent>
         <root_base_size>10GB</root_base_size>

--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -133,11 +133,13 @@ textdomain="control"
     </software>
 
     <partitioning>
-        <try_separate_home config:type="boolean">false</try_separate_home>
-        <limit_try_home>5GB</limit_try_home>
-        <root_space_percent>40</root_space_percent>
+        <try_separate_home config:type="boolean">true</try_separate_home>
+        <limit_try_home>40GB</limit_try_home>
+        <!-- use /var/lib/docker as separate partition if 10+ GB available (fate#323532) -->
+        <home_path>/var/lib/docker</home_path>
+        <root_space_percent>75</root_space_percent>
         <root_base_size>10GB</root_base_size>
-        <root_max_size>10GB</root_max_size>
+        <root_max_size>30GB</root_max_size>
         <proposal_lvm config:type="boolean">false</proposal_lvm>
         <vm_desired_size>15GB</vm_desired_size>
         <vm_home_max_size>25GB</vm_home_max_size>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 26 11:15:57 CEST 2017 - shundhammer@suse.de
+
+- Hack: Use home partition as /var/lib/docker (Fate#323532)
+- 12.2.34
+
+-------------------------------------------------------------------
 Fri Jun 23 07:23:49 UTC 2017 - knut.anderssen@suse.com
 
 - Enable salt-minion service in dashboard role (bsc#1045350)

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -31,7 +31,7 @@ Name:           skelcd-control-CAASP
 # xmllint (for validation)
 BuildRequires:  libxml2-tools
 # RNG validation schema
-BuildRequires:  yast2-installation-control >= 3.1.13.2
+BuildRequires:  yast2-installation-control >= 3.1.13.11
 
 ######################################################################
 #

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -102,7 +102,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        12.2.33
+Version:        12.2.34
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
https://trello.com/c/iOESXcm7/624-5-caasp-hack-separate-data-partition

_control.xml file for this change_

CaaSP needs a separate partition for /var/lib/docker in the storage proposal, and since this would be very tricky to add to the existing proposal mechanism in yast-storage-old, we suggested to repurpose the home partition for that; it can now get another mount point from control.xml. The mechanics and the other parameters in control.xml (size etc.) are still taken from the home partition / volume.

