### PR TITLE
Reduce min size to create separate home for /var/lib/docker

### DIFF
--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -134,7 +134,7 @@ textdomain="control"
 
     <partitioning>
         <try_separate_home config:type="boolean">true</try_separate_home>
-        <limit_try_home>40GB</limit_try_home>
+        <limit_try_home>35GB</limit_try_home>
         <!-- use /var/lib/docker as separate partition if 10+ GB available (fate#323532) -->
         
         <!-- NOTICE: This is a hack, introduced to make this feature possible
@@ -143,7 +143,7 @@ textdomain="control"
              It is strongly advised not to use this in general.
              Please contact the YaST team if you feel you need this. -->
         <home_path>/var/lib/docker</home_path>
-        <root_space_percent>75</root_space_percent>
+        <root_space_percent>80</root_space_percent>
         <root_base_size>10GB</root_base_size>
         <root_max_size>30GB</root_max_size>
         <proposal_lvm config:type="boolean">false</proposal_lvm>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul  4 14:17:04 CEST 2017 - shundhammer@suse.de
+
+- Reduce min size to create a separate /var/lib/docker partition 
+  to 35 GB (Fate#323532)
+- 12.2.37
+
+-------------------------------------------------------------------
 Tue Jun 27 13:16:11 UTC 2017 - jsrain@suse.cz
 
 - enabled the admin-node-setup service on admin (bsc#1046162)

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -102,7 +102,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        12.2.36
+Version:        12.2.37
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
By kukuk's request now reduced the minimum disk size from when on to create a separate home to be repurposed for a separate /var/lib/docker partition.