### PR TITLE
Make fs type for home and root configurable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "yast/rake"
 
 Yast::Tasks.submit_to((ENV["YAST_SUBMIT"] || :casp10).to_sym)
+obs_project = "Devel:YaST:CASP:1.0"
 
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now

--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -143,6 +143,8 @@ textdomain="control"
              It is strongly advised not to use this in general.
              Please contact the YaST team if you feel you need this. -->
         <home_path>/var/lib/docker</home_path>
+        <home_fs>btrfs</home_fs>
+        <root_fs>btrfs</root_fs>
         <root_space_percent>80</root_space_percent>
         <root_base_size>10GB</root_base_size>
         <root_max_size>30GB</root_max_size>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 16 11:35:46 CEST 2017 - shundhammer@suse.de
+
+- Make filesystem type for home and root configurable (bsc#1051762)
+- 12.2.38
+
+-------------------------------------------------------------------
 Tue Jul  4 14:17:04 CEST 2017 - shundhammer@suse.de
 
 - Reduce min size to create a separate /var/lib/docker partition 

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -31,7 +31,7 @@ Name:           skelcd-control-CAASP
 # xmllint (for validation)
 BuildRequires:  libxml2-tools
 # RNG validation schema
-BuildRequires:  yast2-installation-control >= 3.1.13.11
+BuildRequires:  yast2-installation-control >= 3.1.13.12
 
 ######################################################################
 #
@@ -102,7 +102,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        12.2.37
+Version:        12.2.38
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
https://trello.com/c/SQQ1x4Bg/691-5-suse-caasp-10-p2-1051762-docker-on-xfs-by-default

This makes the filesystem type for both home and root in the storage proposal configurable: When home_fs is configurable, root_fs is only a heartbeat away, and it's trivial to add it at the same time.