### PR TITLE
Added yast2-s390 dependency (bsc#1055871)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,2 @@
-# FIXME: switch to yastdevel/cpp:caasp-1_0 when available to avoid running
-# useless Ruby checks
-FROM yastdevel/ruby:caasp-1_0
+FROM yastdevel/ruby
 COPY . /usr/src/app

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,5 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to((ENV["YAST_SUBMIT"] || :casp10).to_sym)
-obs_project = "Devel:YaST:CASP:1.0"
-
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep  1 10:36:24 UTC 2017 - lslezak@suse.cz
+
+- Added yast2-s390 dependency to fix failed disk activation
+  (bsc#1055871)
+- 15.0.0
+
+-------------------------------------------------------------------
 Wed Aug 16 11:35:46 CEST 2017 - shundhammer@suse.de
 
 - Make filesystem type for home and root configurable (bsc#1051762)

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -91,6 +91,7 @@ Provides:       product_control
 #
 %ifarch s390 s390x
 Requires:       yast2-reipl >= 3.1.4
+Requires:       yast2-s390
 %endif
 
 %ifarch %ix86 x86_64
@@ -102,7 +103,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        12.2.38
+Version:        15.0.0
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
to fix possible failed disk activation, similar to https://github.com/yast/skelcd-control-SLED/pull/60 and https://github.com/yast/skelcd-control-SLES/pull/88

- 15.0.0 (4.0.0 would be probably better but as we already started with 12.X lets continue with the SLE numbering here)