### PR TITLE
Backport a fix from IBS

### DIFF
--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -51,6 +51,11 @@ Tue Jun 20 11:42:06 UTC 2017 - jsrain@suse.cz
 - 12.2.32
 
 -------------------------------------------------------------------
+Wed May 24 14:51:45 CEST 2017 - behlert@suse.de
+
+- /usr/lib/skelcd/CD1 instead of /CD1 
+
+-------------------------------------------------------------------
 Wed May 17 11:46:23 CEST 2017 - shundhammer@suse.de
 
 - Added subvolume /home (bsc#1039237)

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -132,8 +132,8 @@ make -C control check
 #
 # Add control file 
 #
-mkdir -p $RPM_BUILD_ROOT/CD1
-install -m 644 control/control.CAASP.xml $RPM_BUILD_ROOT/CD1/control.xml
+mkdir -p $RPM_BUILD_ROOT/usr/lib/skelcd/CD1
+install -m 644 control/control.CAASP.xml $RPM_BUILD_ROOT/usr/lib/skelcd/CD1/control.xml
 
 # install LICENSE (required by build service check)
 mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
@@ -141,7 +141,8 @@ install -m 644 LICENSE $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
 
 %files
 %defattr(644,root,root,755)
-/CD1
+%dir /usr/lib/skelcd
+/usr/lib/skelcd/CD1
 %doc %dir %{_prefix}/share/doc/packages/%{name}
 %doc %{_prefix}/share/doc/packages/%{name}/LICENSE
 


### PR DESCRIPTION
It turned out that the [SUSE:SLE-15:GA/skelcd-control-CAASP](https://build.suse.de/package/show/SUSE:SLE-15:GA/skelcd-control-CAASP) package in IBS contains a change which is missing in Git... :worried: 