### PR TITLE
Adjust control.Kubic.diff, remove non-existing admin-node-setup service (bsc#1058749)

### DIFF
--- a/package/control.Kubic.diff
+++ b/package/control.Kubic.diff
@@ -1,6 +1,6 @@
 --- control/control.CAASP.xml
-+++ control/control.CAASP.xml   2017/06/20 11:05:54
-@@ -264,7 +264,6 @@ 
++++ control/control.CAASP.xml	2017-09-14 22:58:46.070463194 +0200
+@@ -274,12 +274,10 @@
          <id>dashboard_role</id>
  
          <services config:type="list">
@@ -8,7 +8,12 @@
            <service><name>docker</name></service>
            <service><name>etcd</name></service>
            <service><name>kubelet</name></service>
-@@ -276,7 +275,6 @@ 
+           <service><name>salt-minion</name></service>
+-          <service><name>admin-node-setup</name></service>
+         </services>
+       </system_role>
+ 
+@@ -288,7 +286,6 @@
  
          <services config:type="list">
            <service><name>docker</name></service>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 18 12:35:24 UTC 2017 - rbrown@suse.com
+
+- Adjust control.Kubic.diff, remove non-existing admin-node-setup
+  service (bsc#1058749)
+- 15.0.1
+
+-------------------------------------------------------------------
 Fri Sep  1 10:36:24 UTC 2017 - lslezak@suse.cz
 
 - Added yast2-s390 dependency to fix failed disk activation

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -103,7 +103,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        15.0.0
+Version:        15.0.1
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
Needed to resolve http://bugzilla.opensuse.org/show_bug.cgi?id=1058749

A P1/Crit bug that is blocking all releases of Kubic & also impeding Tumbleweed

A fast merge and forward-to-Factory would be appreciated if possible