### PR TITLE
Adjust the install path for Kubic

### DIFF
--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 18 14:40:15 UTC 2017 - lslezak@suse.cz
+
+- Adjust the install path for Kubic (openSUSE still uses the old
+  product builder in OBS)
+
+-------------------------------------------------------------------
 Mon Sep 18 12:35:24 UTC 2017 - rbrown@suse.com
 
 - Adjust control.Kubic.diff, remove non-existing admin-node-setup

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -132,8 +132,13 @@ make -C control check
 #
 # Add control file 
 #
+%if 0%{?is_susecaasp}
 mkdir -p $RPM_BUILD_ROOT/usr/lib/skelcd/CD1
 install -m 644 control/control.CAASP.xml $RPM_BUILD_ROOT/usr/lib/skelcd/CD1/control.xml
+%else
+mkdir -p $RPM_BUILD_ROOT/CD1
+install -m 644 control/control.CAASP.xml $RPM_BUILD_ROOT/CD1/control.xml
+%endif
 
 # install LICENSE (required by build service check)
 mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
@@ -141,8 +146,12 @@ install -m 644 LICENSE $RPM_BUILD_ROOT/%{_prefix}/share/doc/packages/%{name}
 
 %files
 %defattr(644,root,root,755)
+%if 0%{?is_susecaasp}
 %dir /usr/lib/skelcd
 /usr/lib/skelcd/CD1
+%else
+/CD1
+%endif
 %doc %dir %{_prefix}/share/doc/packages/%{name}
 %doc %{_prefix}/share/doc/packages/%{name}/LICENSE
 


### PR DESCRIPTION
openSUSE still uses the old product builder in OBS, for Kubic the path `/usr/lib/skelcd/` cannot be used. Use the old `/CD1` path there.