### PR TITLE
Kubic - copy software/extra_urls from openSUSE Tumbleweed

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+# fold the Travis output to make it better readable
+YELLOW='\033[33;1m'
+NO_COLOR='\033[0m'
+echo travis_fold:start:$BUILD_FLAVOR
+echo -e "${YELLOW}Build '${BUILD_FLAVOR}' flavor${NO_COLOR}"
+
 set -e -x
 
 if [ "$BUILD_FLAVOR" == "kubic" ]; then
@@ -22,3 +28,6 @@ make -C control check
 # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
 # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
 yast-travis-ruby
+
+set +x
+echo travis_fold:end:$BUILD_FLAVOR

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 
 before_install:
   - docker build -t skelcd-control-caasp-image .
+    # list the installed packages (just for easier debugging)
+  - docker run --rm -it skelcd-control-caasp-image rpm -qa | sort
 
 script:
   # the builds can run sequentially, the build in Docker is fast and Docker isolates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,4 @@
 FROM yastdevel/ruby
+# install the openSUSE control.xml, we need to copy some parts to Kubic
+RUN zypper --non-interactive in --no-recommends skelcd-control-openSUSE
 COPY . /usr/src/app

--- a/control/Makefile
+++ b/control/Makefile
@@ -4,7 +4,7 @@ check: /usr/share/YaST2/control/control.rng
 	xmllint --relaxng /usr/share/YaST2/control/control.rng --noout *.xml
 
 # generate the control.Kubic.xml file
-control.Kubic.xml: control.Kubic.xsl control.CAASP.xml
+control.Kubic.xml: control.Kubic.xsl control.CAASP.xml /usr/lib/skelcd/CD1/control.xml
 	xsltproc control.Kubic.xsl control.CAASP.xml > control.Kubic.xml
 
 clean:

--- a/control/control.Kubic.xsl
+++ b/control/control.Kubic.xsl
@@ -22,4 +22,12 @@
   <!-- a trick to remove the remaining empty line after node removal -->
   <xsl:template match="text()[following-sibling::node()[1][self::n:service[n:name='admin-node-setup']]]" />
 
+  <!-- Add the "extra_urls" part from the normal openSUSE control file -->
+  <xsl:template match="n:software">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+      <!-- Make sure this is the openSUSE control file! -->
+      <xsl:copy-of select="document('/usr/lib/skelcd/CD1/control.xml')/*/n:software/n:extra_urls"/>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec  5 08:31:11 UTC 2017 - lslezak@suse.cz
+
+- openSUSE Kubic: copy "extra_urls" configuration from the standard
+  openSUSE product (bsc#1071217)
+- 15.0.6
+
+-------------------------------------------------------------------
 Thu Oct 26 15:15:58 CEST 2017 - snwint@suse.de
 
 - adjust subvolume list in control.xml to support all archs (fate#318196)

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -111,7 +111,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        15.0.5
+Version:        15.0.6
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -37,6 +37,8 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 # xsltproc - for building control.Kubic.xml from control.CAASP.xml
 BuildRequires:  libxslt-tools
 BuildRequires:  diffutils
+# we need to copy some parts from the openSUSE control.xml to Kubic
+BuildRequires:  skelcd-control-openSUSE
 %endif
 
 ######################################################################


### PR DESCRIPTION
- Copy the TW repositories to the Kubic `control.xml`, Kubic is built on top of TW
- See [the Travis output](https://travis-ci.org/yast/skelcd-control-CAASP/builds/311196514#L1217) for the result
- Travis improvements
  - Added Travis folding for better readability
  - List the packages (just for debugging)