### PR TITLE
openSUSE Kubic still uses the old /CD1 control file path

### DIFF
--- a/control/Makefile
+++ b/control/Makefile
@@ -4,7 +4,7 @@ check: /usr/share/YaST2/control/control.rng
 	xmllint --relaxng /usr/share/YaST2/control/control.rng --noout *.xml
 
 # generate the control.Kubic.xml file
-control.Kubic.xml: control.Kubic.xsl control.CAASP.xml /usr/lib/skelcd/CD1/control.xml
+control.Kubic.xml: control.Kubic.xsl control.CAASP.xml /CD1/control.xml
 	xsltproc control.Kubic.xsl control.CAASP.xml > control.Kubic.xml
 
 clean:

--- a/control/Makefile
+++ b/control/Makefile
@@ -4,7 +4,7 @@ check: /usr/share/YaST2/control/control.rng
 	xmllint --relaxng /usr/share/YaST2/control/control.rng --noout *.xml
 
 # generate the control.Kubic.xml file
-control.Kubic.xml: control.Kubic.xsl control.CAASP.xml /CD1/control.xml
+control.Kubic.xml: control.Kubic.xsl control.CAASP.xml
 	xsltproc control.Kubic.xsl control.CAASP.xml > control.Kubic.xml
 
 clean:

--- a/control/control.Kubic.xsl
+++ b/control/control.Kubic.xsl
@@ -27,7 +27,7 @@
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
       <!-- Make sure this is the openSUSE control file! -->
-      <xsl:copy-of select="document('/usr/lib/skelcd/CD1/control.xml')/*/n:software/n:extra_urls"/>
+      <xsl:copy-of select="document('/CD1/control.xml')/*/n:software/n:extra_urls"/>
     </xsl:copy>
   </xsl:template>
 </xsl:stylesheet>

--- a/control/control.Kubic.xsl
+++ b/control/control.Kubic.xsl
@@ -26,7 +26,8 @@
   <xsl:template match="n:software">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <!-- Make sure this is the openSUSE control file! -->
+      <!-- Make sure this is the openSUSE control file!, try both (old and the new) locations -->
+      <xsl:copy-of select="document('/usr/lib/skelcd/CD1/control.xml')/*/n:software/n:extra_urls"/>
       <xsl:copy-of select="document('/CD1/control.xml')/*/n:software/n:extra_urls"/>
     </xsl:copy>
   </xsl:template>


### PR DESCRIPTION
openSUSE still uses the old `/CD1` control file path.