### PR TITLE
CaaSP 4 pulls images from SUSE Registry, so we don't need

### DIFF
--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -251,7 +251,6 @@ textdomain="control"
         <id>dashboard_role</id>
 
         <services config:type="list">
-          <service><name>container-feeder</name></service>
           <service><name>docker</name></service>
           <service><name>etcd</name></service>
           <service><name>kubelet</name></service>
@@ -269,7 +268,6 @@ textdomain="control"
 
         <services config:type="list">
           <service><name>docker</name></service>
-          <service><name>container-feeder</name></service>
           <service><name>salt-minion</name></service>
           <service><name>systemd-timesyncd</name></service>
         </services>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,3 +1,9 @@
+Thu Oct 11 14:43:55 UTC 2018 - jmassaguerpla@suse.com
+
+- fix bsc#1111541: do not enable container-feeder since this does
+  not exist in caasp4.
+- 15.3
+
 -------------------------------------------------------------------
 Thu Oct 11 08:35:10 UTC 2018 - jmassaguerpla@suse.com
 

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -112,7 +112,7 @@ ExcludeArch:    %ix86 s390
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        15.2
+Version:        15.3
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
container-feeder anymore

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>