### PR TITLE
Force btrfs for Guided Setup

### DIFF
--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -144,6 +144,8 @@ textdomain="control"
                 <mount_point>/</mount_point>
                 <!-- Default == final, since the user can't change it -->
                 <fs_type>btrfs</fs_type>
+                <!-- Do not allow to select other fs type in the guided setup -->
+                <fs_types>btrfs</fs_types>
                 <desired_size config:type="disksize">25 GiB</desired_size>
                 <min_size config:type="disksize">20 GiB</min_size>
                 <max_size config:type="disksize">30 GiB</max_size>
@@ -216,6 +218,8 @@ textdomain="control"
                 <mount_point>/var/lib/docker</mount_point>
                 <!-- Default == final, since the user can't change it -->
                 <fs_type>btrfs</fs_type>
+                <!-- Do not allow to select other fs type in the guided setup -->
+                <fs_types>btrfs</fs_types>
                 <snapshots config:type="boolean">false</snapshots>
                 <snapshots_configurable config:type="boolean">false</snapshots_configurable>
 

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 31 10:16:01 UTC 2019 - jlopez@suse.com
+
+- Force btrfs filesystem in Guided Setup (needed for bsc#1099485).
+- 15.5
+
+-------------------------------------------------------------------
 Tue Nov  6 13:45:16 UTC 2018 - lslezak@suse.cz
 
 - Display new role dialogs in the workflow (FATE#325834)

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -101,7 +101,7 @@ ExcludeArch:    %ix86 s390
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        15.4
+Version:        15.5
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
In the installation summary, the "Partitioning" header was directly linking to the Expert Partitioner. This was modified, and now it links to the storage client, where your can select both: the Guided Setup and the Expert Partitioner.

Due to the user can now perform a Guided Setup, the control file option `fs_types` should be defined, otherwise the user could select another fs type different to btrfs. When `fs_types` is not defined, a fallback list of filesystems are proposed. For example, for the root and home partition the user could select the following filesystems: ext2, ext3, ext4, btrfs, xfs.

By defining `fs_types`, the list of possible filesystems will be restricted to such values. So, with the changes in this PR, the only one options will be btrfs for both: root and `/var/lib/docker`.

Related to PBI: https://trello.com/c/53IEUxrB/577-susecaas-platform-4-p2-1099485-caasp-specific-partitioning-warning-dialog-missing-in-storage-ng
 