### PR TITLE
[LATER: CaaSP 5.0?] Update base product license directory 

### DIFF
--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -55,7 +55,7 @@ textdomain="control"
         </save_instsys_content>
 
         <!-- FATE: #304865: Enhance YaST Modules to cooperate better handling the product licenses -->
-        <base_product_license_directory>/etc/YaST2/licenses/base/</base_product_license_directory>
+        <base_product_license_directory>/usr/share/licenses/product/base/</base_product_license_directory>
 
         <!-- #303798: YaST2 runlevel editor: offer easy enablement and configuration of runlevel 4 -->
         <rle_offer_rulevel_4 config:type="boolean">true</rle_offer_rulevel_4>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 12 15:30:53 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Updated the base product license directory
+  (fate#324053, jsc#SLE-4173)
+- 15.6
+
+-------------------------------------------------------------------
 Thu Jan 31 10:16:01 UTC 2019 - jlopez@suse.com
 
 - Force btrfs filesystem in Guided Setup (needed for bsc#1099485).

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -101,7 +101,7 @@ ExcludeArch:    %ix86 s390
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        15.5
+Version:        15.6
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
After the changes made for fate#324053 / jsc#SLE-4173, the license for the base product will be located at `/usr/share/licenses/product/base` instead of `/etc/YaST2/licenses/base`.

---

Related to https://github.com/yast/yast-yast2/pull/907