### PR TITLE
add /var/lib/btrfs to list of btrfs subvolumes (bsc#1076548)

### DIFF
--- a/control/control.CAASP.xml
+++ b/control/control.CAASP.xml
@@ -188,6 +188,9 @@ textdomain="control"
                 <path>var/spool</path>
             </subvolume>
             <subvolume>
+                <path>var/lib/btrfs</path>
+            </subvolume>
+            <subvolume>
                 <path>var/lib/ca-certificates</path>
             </subvolume>
             <subvolume>

--- a/package/skelcd-control-CAASP.changes
+++ b/package/skelcd-control-CAASP.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 25 11:18:04 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- add /var/lib/btrfs to list of btrfs subvolumes (bsc#1076548)
+- 12.2.41
+
+-------------------------------------------------------------------
 Fri Mar 23 07:25:26 UTC 2018 - jsrain@suse.cz
 
 - added subvolume for /var/lib/containers (bsc#1084469)

--- a/package/skelcd-control-CAASP.spec
+++ b/package/skelcd-control-CAASP.spec
@@ -102,7 +102,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-CAASP
 AutoReqProv:    off
-Version:        12.2.40
+Version:        12.2.41
 Release:        0
 Summary:        The CaaSP control file needed for installation
 License:        MIT


### PR DESCRIPTION
The same as https://github.com/yast/skelcd-control-CAASP/pull/81 but for branch `SLE-12-SP4`.